### PR TITLE
Chore: Switch to NFT.Storage endpoint to improve loading speed

### DIFF
--- a/components/Constants.js
+++ b/components/Constants.js
@@ -1,0 +1,1 @@
+export const IPFS_URL = "https://nftstorage.link/ipfs/";

--- a/components/TokenTiles.js
+++ b/components/TokenTiles.js
@@ -18,7 +18,7 @@ const TokenTiles = (props) => {
       <div className="main-container">
         {address ? (
           fetchingTokens ? (
-            <p className="card-not-loaded-desc">fetching box tokens..</p>
+            <p className="card-not-loaded-desc">fetching box tokens.. It might take few minutes.</p>
           ) : (
             <div className="tile-container">
               {tokens.map((tokenBalance, idx) => {


### PR DESCRIPTION
What I have done:
- Switched the IPFS gateway from `ipfs.io` to `NFT.Storage` gateway.
- Added text to inform users to wait for few minutes as loading can take some time.
- Logging time to load each seed as well as all the seed metadata.